### PR TITLE
fix: bump mindustry to v159.6 and update mod calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,6 @@ version '1.0'
 
 sourceSets.main.java.srcDirs = ["src"]
 
-
-sourceSets.main.java.srcDirs = ["src"]
-
 repositories{
     mavenCentral()
 
@@ -43,7 +40,7 @@ ext{
     // - latest: depend on the latest release of mindustry
     // - be: depend on the very latest commit of mindustry
     // - v<number>: depend on a specific commit
-    mindustryVersion = "v159.2"
+    mindustryVersion = "v159.6"
     isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     sdkRoot = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
 }

--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.58.3-v8
+version: v4.58.4-v8
 
 minGameVersion: 159
 

--- a/src/mindustrytool/services/UpdateAvailableDialog.java
+++ b/src/mindustrytool/services/UpdateAvailableDialog.java
@@ -48,7 +48,7 @@ public class UpdateAvailableDialog extends BaseDialog {
             try {
                 remove();
                 Vars.ui.mods.show();
-                Vars.ui.mods.githubImportMod(Config.REPO_URL, true);
+                Vars.ui.mods.githubImportMod(Config.REPO_URL, true, true);
                 Vars.ui.mods.toFront();
                 Timer.schedule(() -> Vars.ui.loadfrag.toFront(), 0.2f);
             } catch (Exception e) {

--- a/src/mindustrytool/ui/ChangelogDialog.java
+++ b/src/mindustrytool/ui/ChangelogDialog.java
@@ -197,7 +197,7 @@ public class ChangelogDialog extends BaseDialog {
                 t.button("@install", Icon.download, () -> {
                     try {
                         Vars.ui.mods.show();
-                        Vars.ui.mods.githubImportMod(Config.REPO_URL, true, "tags/" + finalTagName);
+                        Vars.ui.mods.githubImportMod(Config.REPO_URL, true, "tags/" + finalTagName, true);
                         Vars.ui.mods.toFront();
                         Timer.schedule(() -> Vars.ui.loadfrag.toFront(), 0.2f);
                         // Close dialogs to show the mod installation progress


### PR DESCRIPTION
Remove redundant duplicate sourceSets configuration in build.gradle Update githubImportMod method calls to match the new API signature from the bumped dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mod installation and update handling from the in-app update and changelog dialogs.
  * Updated the Mindustry dependency to v159.6.
  * Incremented the mod version to v4.58.4-v8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->