### PR TITLE
fix(playerconnect): fix room closed when change to new map in campaig…

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.58.4-v8
+version: v4.58.5-v8
 
 minGameVersion: 159
 

--- a/src/mindustrytool/features/playerconnect/PlayerConnect.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnect.java
@@ -18,13 +18,11 @@ import arc.util.Threads;
 import arc.util.Time;
 import arc.util.Timer;
 import mindustry.Vars;
-import mindustry.core.GameState;
 import mindustry.game.EventType;
 import mindustry.game.Team;
 import mindustry.game.EventType.PlayerIpBanEvent;
 import mindustry.game.EventType.PlayerJoin;
 import mindustry.game.EventType.PlayerLeave;
-import mindustry.game.EventType.StateChangeEvent;
 import mindustry.game.EventType.WorldLoadEndEvent;
 import mindustry.gen.Call;
 import mindustry.gen.Player;
@@ -61,13 +59,6 @@ public class PlayerConnect {
 
         Events.run(WorldLoadEndEvent.class, () -> {
             updateStats();
-        });
-
-        Events.on(StateChangeEvent.class, event -> {
-            if (event.to == GameState.State.menu && isHosting()) {
-                close();
-                Vars.ui.showInfoFade("Close room when back to menu");
-            }
         });
 
         Timer.schedule(() -> {
@@ -220,6 +211,10 @@ public class PlayerConnect {
     public static void join(PlayerConnectLink link, String password, Runnable success) {
         if (link == null) {
             throw new IllegalArgumentException("Link cannot be null.");
+        }
+
+        if (isHosting()){
+            close();
         }
 
         Vars.ui.loadfrag.show("@connecting");


### PR DESCRIPTION
…n, close active host room before initiating new connection

clean up unused GameState and StateChangeEvent imports replace outdated menu-triggered room closing with proactive cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Joining another room now automatically closes any currently hosted room first.
* **Bug Fixes**
  * Improved room connection handling when switching from hosting to joining.
  * Prevented unintended room closures when returning to the main menu.
* **Chores**
  * Updated the mod version to v4.58.5-v8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->