### PR TITLE
fix: bump mindustry dependency to v159.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext{
     // - latest: depend on the latest release of mindustry
     // - be: depend on the very latest commit of mindustry
     // - v<number>: depend on a specific commit
-    mindustryVersion = "v159.6"
+    mindustryVersion = "v159.7"
     isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     sdkRoot = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
 }

--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.58.5-v8
+version: v4.58.6-v8
 
 minGameVersion: 159
 

--- a/src/mindustrytool/features/browser/map/MapDialog.java
+++ b/src/mindustrytool/features/browser/map/MapDialog.java
@@ -385,13 +385,13 @@ public class MapDialog extends BaseDialog {
                     mapFile.writeBytes(result);
                     Vars.maps.importMap(mapFile);
                     ui.showInfoFade("@map.saved");
-                } catch (Exception e) {
-                    ui.showInfoFade(e.getMessage());
+                } catch (Throwable e) {
+                    ui.showInfoFade("Error " + e.getMessage());
                 }
             });
         }).exceptionally(error -> {
             Core.app.post(() -> {
-                ui.showInfoFade(error.getMessage());
+                ui.showInfoFade("Error " + error.getMessage());
             });
             return null;
         });

--- a/src/mindustrytool/features/display/teamresource/TeamResourceFeature.java
+++ b/src/mindustrytool/features/display/teamresource/TeamResourceFeature.java
@@ -413,25 +413,31 @@ public class TeamResourceFeature extends Table implements Feature {
         if (coreItems == null)
             return "0";
 
-        int amount = coreItems.get(item);
-        int rate = rateDisplay.get(item);
+        try {
 
-        if (TeamResourceConfig.alwaysShowFlowRate()) {
-            return formatAmountWithRate(amount, rate);
+            int amount = coreItems.get(item);
+            int rate = rateDisplay.get(item);
+
+            if (TeamResourceConfig.alwaysShowFlowRate()) {
+                return formatAmountWithRate(amount, rate);
+            }
+
+            if (viewingStats) {
+                return formatRate(rate);
+            }
+
+            String color = "[white]";
+            if (rate < 0) {
+                color = "[scarlet]";
+            } else if (rate > 0) {
+                color = "[lime]";
+            }
+
+            return color + UI.formatAmount(amount);
+        } catch (Exception e) {
+            Log.err("Fail to format item", e);
+            return "0";
         }
-
-        if (viewingStats) {
-            return formatRate(rate);
-        }
-
-        String color = "[white]";
-        if (rate < 0) {
-            color = "[scarlet]";
-        } else if (rate > 0) {
-            color = "[lime]";
-        }
-
-        return color + UI.formatAmount(amount);
     }
 
     private String formatAmountWithRate(int amount, int rate) {

--- a/src/mindustrytool/services/MapService.java
+++ b/src/mindustrytool/services/MapService.java
@@ -14,8 +14,8 @@ public class MapService {
         CompletableFuture<byte[]> future = new CompletableFuture<>();
 
         Http.get(Config.API_URL + "maps/" + id + "/data")
-                .error(future::completeExceptionally)
                 .timeout(10000)
+                .error(future::completeExceptionally)
                 .submit(result -> {
                     future.complete(result.getResult());
                 });

--- a/src/mindustrytool/services/UpdateAvailableDialog.java
+++ b/src/mindustrytool/services/UpdateAvailableDialog.java
@@ -51,7 +51,7 @@ public class UpdateAvailableDialog extends BaseDialog {
                 Vars.ui.mods.githubImportMod(Config.REPO_URL, true, true);
                 Vars.ui.mods.toFront();
                 Timer.schedule(() -> Vars.ui.loadfrag.toFront(), 0.2f);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 Log.err(e);
                 Vars.ui.showException(e);
             }

--- a/src/mindustrytool/ui/ChangelogDialog.java
+++ b/src/mindustrytool/ui/ChangelogDialog.java
@@ -202,7 +202,7 @@ public class ChangelogDialog extends BaseDialog {
                         Timer.schedule(() -> Vars.ui.loadfrag.toFront(), 0.2f);
                         // Close dialogs to show the mod installation progress
                         this.hide();
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         Log.err(e);
                         Vars.ui.showException(e);
                     }


### PR DESCRIPTION
- rearrange http timeout and error handler order in MapService
- catch Throwable instead of Exception in ChangelogDialog, UpdateAvailableDialog and MapDialog
- add "Error " prefix to error message in MapDialog's exceptionally callback
- wrap TeamResourceFeature's item formatting logic in try-catch with logging and fallback 0 return

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated compatibility with Mindustry v159.7.
  - Released version v4.58.6-v8.

- **Bug Fixes**
  - Improved error handling when downloading or importing maps.
  - Clarified error messages shown during failed operations.
  - Prevented team resource displays from failing when formatting encounters an error.
  - Improved timeout handling for map downloads.
  - Strengthened error handling when installing updates or changelog items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->