### PR TITLE
chore: set default translation provider to Gemini

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.58.6-v8
+version: v4.58.7-v8
 
 minGameVersion: 159
 

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class ChatTranslationFeature implements Feature {
     private final Seq<TranslationProvider> providers = new Seq<>();
-    private final TranslationProvider defaultTranslationProvider = new MindustryToolTranslationProvider();
+    private final TranslationProvider defaultTranslationProvider = new GeminiTranslationProvider();
     private String lastError = null;
     private TranslationProvider currentProvider = defaultTranslationProvider;
 
@@ -63,7 +63,7 @@ public class ChatTranslationFeature implements Feature {
         Main.registerPacketPlacement(SendMessageCallPacket2.class, SendTranslatedMessageCallPacket2::new);
 
         providers.add(defaultTranslationProvider);
-        providers.add(new GeminiTranslationProvider());
+        // providers.add(new GeminiTranslationProvider());
         providers.add(new DeepLTranslationProvider());
 
         providers.each(TranslationProvider::init);


### PR DESCRIPTION
comment out GeminiTranslationProvider addition to providers list to avoid it appearing in the provider selection menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default chat translation provider to Gemini for improved translation support.

* **Chores**
  * Updated the mod version to v4.58.7-v8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->