### PR TITLE
feat(browser): add .png extension to schematic and map image URLs

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.58.7-v8
+version: v4.59.0-v8
 
 minGameVersion: 159
 

--- a/src/mindustrytool/features/browser/map/MapImage.java
+++ b/src/mindustrytool/features/browser/map/MapImage.java
@@ -42,7 +42,7 @@ public class MapImage extends Image {
         StringBuilder sb = new StringBuilder(Config.IMAGE_URL);
         sb.append("maps/")
                 .append(id)
-                .append("/image");
+                .append("/image.png");
         if (preview) {
             sb.append("?variant=preview");
         }

--- a/src/mindustrytool/features/browser/schematic/SchematicImage.java
+++ b/src/mindustrytool/features/browser/schematic/SchematicImage.java
@@ -43,7 +43,7 @@ public class SchematicImage extends Image {
         StringBuilder sb = new StringBuilder(Config.IMAGE_URL);
         sb.append("schematics/")
                 .append(id)
-                .append("/image");
+                .append("/image.png");
         if (preview) {
             sb.append("?variant=preview");
         }


### PR DESCRIPTION
- Append .png extension to schematic and map image link URLs
- Bump minor version in mod.hjson to v4.59.0-v8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated map and schematic image previews to use the correct image format, improving compatibility and reliability.
  - Preview parameters are now preserved when loading map images.

- **Chores**
  - Updated the mod version to v4.59.0-v8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->