### PR TITLE
refactor: rename id to itemId across map and schematic handling

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.59.0-v8
+version: v4.59.1-v8
 
 minGameVersion: 159
 

--- a/src/mindustrytool/features/browser/map/MapDialog.java
+++ b/src/mindustrytool/features/browser/map/MapDialog.java
@@ -248,10 +248,10 @@ public class MapDialog extends BaseDialog {
             preview.table(buttons -> {
                 buttons.center().defaults().size(PREVIEW_BUTTON_SIZE);
 
-                buttons.button(Icon.download, Styles.emptyi, () -> handleDownloadMap(data.getId()))
+                buttons.button(Icon.download, Styles.emptyi, () -> handleDownloadMap(data.getItemId()))
                         .pad(2);
                 buttons.button(Icon.info, Styles.emptyi,
-                        () -> MapService.findMapById(data.getId())
+                        () -> MapService.findMapById(data.getItemId())
                                 .thenAccept(m -> Core.app.post(() -> infoDialog.show(m))))
                         .tooltip("@info.title");
             }).growX().height(PREVIEW_BUTTON_SIZE);
@@ -259,7 +259,7 @@ public class MapDialog extends BaseDialog {
             preview.row();
 
             preview.stack(
-                    new Table(t -> t.add(new MapImage(data.getId(), true))),
+                    new Table(t -> t.add(new MapImage(data.getItemId(), true))),
                     new Table(nameTable -> {
                         nameTable.top();
                         nameTable.table(Styles.black3, c -> {
@@ -299,7 +299,7 @@ public class MapDialog extends BaseDialog {
             return;
         }
 
-        MapService.findMapById(data.getId()).thenAccept(m -> Core.app.post(() -> infoDialog.show(m)));
+        MapService.findMapById(data.getItemId()).thenAccept(m -> Core.app.post(() -> infoDialog.show(m)));
     }
 
     private void rebuildFooter() {
@@ -377,11 +377,11 @@ public class MapDialog extends BaseDialog {
         rebuildFooter();
     }
 
-    public static void handleDownloadMap(String id) {
-        MapService.downloadMap(id).thenAccept(result -> {
+    public static void handleDownloadMap(String itemId) {
+        MapService.downloadMap(itemId).thenAccept(result -> {
             Core.app.post(() -> {
                 try {
-                    Fi mapFile = Vars.customMapDirectory.child(id);
+                    Fi mapFile = Vars.customMapDirectory.child(itemId);
                     mapFile.writeBytes(result);
                     Vars.maps.importMap(mapFile);
                     ui.showInfoFade("@map.saved");

--- a/src/mindustrytool/features/browser/map/MapImage.java
+++ b/src/mindustrytool/features/browser/map/MapImage.java
@@ -28,20 +28,20 @@ public class MapImage extends Image {
     public float thickness = 4f;
     public Color borderColor = Pal.gray;
 
-    private final String id;
+    private final String itemId;
     private final boolean preview;
     private TextureRegion lastTexture;
     private static ObjectMap<String, TextureRegion> textureCache = new ObjectMap<>();
     private final String imageUrl;
 
-    public MapImage(String id, boolean preview) {
+    public MapImage(String itemId, boolean preview) {
         super(Tex.clear);
-        this.id = id;
+        this.itemId = itemId;
         this.preview = preview;
 
         StringBuilder sb = new StringBuilder(Config.IMAGE_URL);
         sb.append("maps/")
-                .append(id)
+                .append(itemId)
                 .append("/image.png");
         if (preview) {
             sb.append("?variant=preview");
@@ -64,7 +64,7 @@ public class MapImage extends Image {
 
             if (!textureCache.containsKey(imageUrl)) {
                 textureCache.put(imageUrl, lastTexture = Core.atlas.find("nomap"));
-                var file = Main.mapsDir.child(id + (preview ? "_preview" : "") + ".png");
+                var file = Main.mapsDir.child(itemId + (preview ? "_preview" : "") + ".png");
 
                 if (file.exists()) {
                     byte[] result = file.readBytes();
@@ -76,7 +76,7 @@ public class MapImage extends Image {
                             textureCache.put(imageUrl, new TextureRegion(tex));
                             pix.dispose();
                         } catch (Exception e) {
-                            Log.err(id, e);
+                            Log.err(itemId, e);
                         }
                     });
 
@@ -86,7 +86,7 @@ public class MapImage extends Image {
                             .error(error -> {
                                 if (!(error instanceof HttpStatusException requestError)
                                         || requestError.status != HttpStatus.NOT_FOUND) {
-                                    Log.err(id, error);
+                                    Log.err(itemId, error);
                                     Timer.schedule(() -> textureCache.remove(imageUrl), 5);
                                 }
                             })
@@ -101,7 +101,7 @@ public class MapImage extends Image {
                                         file.writeBytes(result);
 
                                     } catch (Exception error) {
-                                        Log.err(id, error);
+                                        Log.err(itemId, error);
                                     }
                                 });
 
@@ -112,7 +112,7 @@ public class MapImage extends Image {
                                         textureCache.put(imageUrl, new TextureRegion(tex));
                                         pix.dispose();
                                     } catch (Exception e) {
-                                        Log.err(id, e);
+                                        Log.err(itemId, e);
                                     }
                                 });
 
@@ -126,7 +126,7 @@ public class MapImage extends Image {
             Draw.reset();
 
         } catch (Exception error) {
-            Log.err(id, error);
+            Log.err(itemId, error);
         }
     }
 }

--- a/src/mindustrytool/features/browser/map/MapInfoDialog.java
+++ b/src/mindustrytool/features/browser/map/MapInfoDialog.java
@@ -35,7 +35,7 @@ public class MapInfoDialog extends BaseDialog {
         boolean portrait = Core.graphics.isPortrait();
 
         if (portrait) {
-            cont.add(new MapImage(data.getId(), false)).scaling(Scaling.fit)
+            cont.add(new MapImage(data.getItemId(), false)).scaling(Scaling.fit)
                     .maxHeight(Core.graphics.getHeight() * 0.45f)
                     .growX()
                     .pad(10f)
@@ -49,7 +49,7 @@ public class MapInfoDialog extends BaseDialog {
 
                 var size = Math.max(Core.graphics.getHeight() * 0.5f, Core.graphics.getWidth() * 0.5f);
 
-                main.add(new MapImage(data.getId(), false)).scaling(Scaling.fit)
+                main.add(new MapImage(data.getItemId(), false)).scaling(Scaling.fit)
                         .height(size)
                         .width(size)
                         .pad(10f)
@@ -61,7 +61,7 @@ public class MapInfoDialog extends BaseDialog {
 
         buttons.clearChildren();
         buttons.defaults().size(Core.graphics.isPortrait() ? 150f : 210f, 64f);
-        buttons.button("@open", Icon.link, () -> Core.app.openURI(Config.WEB_URL + "/maps/" + data.getId())).pad(4);
+        buttons.button("@open", Icon.link, () -> Core.app.openURI(Config.WEB_URL + "/maps/" + data.getItemId())).pad(4);
         buttons.button("@back", Icon.left, this::hide);
 
         show();

--- a/src/mindustrytool/features/browser/schematic/SchematicDialog.java
+++ b/src/mindustrytool/features/browser/schematic/SchematicDialog.java
@@ -253,12 +253,12 @@ public class SchematicDialog extends BaseDialog {
             preview.table(buttons -> {
                 buttons.center().defaults().size(PREVIEW_BUTTON_SIZE);
 
-                buttons.button(Icon.copy, Styles.emptyi, () -> handleCopySchematic(data.getId()))
+                buttons.button(Icon.copy, Styles.emptyi, () -> handleCopySchematic(data.getItemId()))
                         .pad(2);
-                buttons.button(Icon.download, Styles.emptyi, () -> handleDownloadSchematic(data.getId()))
+                buttons.button(Icon.download, Styles.emptyi, () -> handleDownloadSchematic(data.getItemId()))
                         .pad(2);
                 buttons.button(Icon.info, Styles.emptyi,
-                        () -> SchematicService.findSchematicById(data.getId())
+                        () -> SchematicService.findSchematicById(data.getItemId())
                                 .thenAccept(schem -> Core.app.post(() -> infoDialog.show(schem))))
                         .tooltip("@info.title");
             }).growX().height(PREVIEW_BUTTON_SIZE);
@@ -266,7 +266,7 @@ public class SchematicDialog extends BaseDialog {
             preview.row();
 
             preview.stack(
-                    new Table(t -> t.add(new SchematicImage(data.getId(), true))),
+                    new Table(t -> t.add(new SchematicImage(data.getItemId(), true))),
                     new Table(nameTable -> {
                         nameTable.top();
                         nameTable.table(Styles.black3, c -> {
@@ -307,13 +307,13 @@ public class SchematicDialog extends BaseDialog {
         }
 
         if (state.isMenu()) {
-            SchematicService.findSchematicById(data.getId())
+            SchematicService.findSchematicById(data.getItemId())
                     .thenAccept(schem -> Core.app.post(() -> infoDialog.show(schem)));
         } else {
             if (!state.rules.schematicsAllowed) {
                 ui.showInfo("@schematic.disabled");
             } else {
-                handleDownloadSchematicData(data.getId(),
+                handleDownloadSchematicData(data.getItemId(),
                         content -> control.input.useSchematic(Utils.readSchematic(content)));
                 hide();
             }
@@ -395,8 +395,8 @@ public class SchematicDialog extends BaseDialog {
         rebuildFooter();
     }
 
-    public static void handleCopySchematic(String id) {
-        handleDownloadSchematicData(id, data -> {
+    public static void handleCopySchematic(String itemId) {
+        handleDownloadSchematicData(itemId, data -> {
             Core.app.post(() -> {
                 try {
                     Schematic s = Utils.readSchematic(data);
@@ -409,9 +409,9 @@ public class SchematicDialog extends BaseDialog {
         });
     }
 
-    public static void handleDownloadSchematic(String id) {
-        handleDownloadSchematicData(id, data -> {
-            SchematicService.findSchematicById(id).thenAccept(detail -> {
+    public static void handleDownloadSchematic(String itemId) {
+        handleDownloadSchematicData(itemId, data -> {
+            SchematicService.findSchematicById(itemId).thenAccept(detail -> {
                 try {
                     Schematic s = Utils.readSchematic(data);
                     Core.app.post(() -> {
@@ -427,8 +427,8 @@ public class SchematicDialog extends BaseDialog {
         });
     }
 
-    private static void handleDownloadSchematicData(String id, Cons<String> cons) {
-        SchematicService.downloadSchematic(id).thenAccept(result -> {
+    private static void handleDownloadSchematicData(String itemId, Cons<String> cons) {
+        SchematicService.downloadSchematic(itemId).thenAccept(result -> {
             cons.get(new String(Base64Coder.encode(result)));
         })
                 .exceptionally((err) -> {

--- a/src/mindustrytool/features/browser/schematic/SchematicImage.java
+++ b/src/mindustrytool/features/browser/schematic/SchematicImage.java
@@ -28,21 +28,21 @@ public class SchematicImage extends Image {
     public float thickness = 4f;
     public Color borderColor = Pal.gray;
 
-    private final String id;
+    private final String itemId;
     private final boolean preview;
     private TextureRegion lastTexture;
     private final String imageUrl;
 
     private static ObjectMap<String, TextureRegion> textureCache = new ObjectMap<>();
 
-    public SchematicImage(String id, boolean preview) {
+    public SchematicImage(String itemId, boolean preview) {
         super(Tex.clear);
-        this.id = id;
+        this.itemId = itemId;
         this.preview = preview;
 
         StringBuilder sb = new StringBuilder(Config.IMAGE_URL);
         sb.append("schematics/")
-                .append(id)
+                .append(itemId)
                 .append("/image.png");
         if (preview) {
             sb.append("?variant=preview");
@@ -73,7 +73,7 @@ public class SchematicImage extends Image {
             if (!textureCache.containsKey(imageUrl)) {
                 textureCache.put(imageUrl, lastTexture = Core.atlas.find("nomap"));
 
-                var file = Main.schematicDir.child(id + (preview ? "_preview" : "") + ".png");
+                var file = Main.schematicDir.child(itemId + (preview ? "_preview" : "") + ".png");
 
                 if (file.exists()) {
                     byte[] result = file.readBytes();
@@ -85,7 +85,7 @@ public class SchematicImage extends Image {
                             textureCache.put(imageUrl, new TextureRegion(tex));
                             pix.dispose();
                         } catch (Exception e) {
-                            Log.err(id, e);
+                            Log.err(itemId, e);
                         }
                     });
                 } else {
@@ -110,7 +110,7 @@ public class SchematicImage extends Image {
                                         try {
                                             file.writeBytes(result);
                                         } catch (Exception error) {
-                                            Log.err(id, error);
+                                            Log.err(itemId, error);
                                         }
                                     });
 
@@ -121,11 +121,11 @@ public class SchematicImage extends Image {
                                             textureCache.put(imageUrl, new TextureRegion(tex));
                                             pix.dispose();
                                         } catch (Exception e) {
-                                            Log.err(id, e);
+                                            Log.err(itemId, e);
                                         }
                                     });
                                 } catch (Exception error) {
-                                    Log.err(id, error);
+                                    Log.err(itemId, error);
                                 }
 
                             });
@@ -133,7 +133,7 @@ public class SchematicImage extends Image {
             }
 
         } catch (Exception error) {
-            Log.err(id, error);
+            Log.err(itemId, error);
         }
     }
 }

--- a/src/mindustrytool/features/browser/schematic/SchematicInfoDialog.java
+++ b/src/mindustrytool/features/browser/schematic/SchematicInfoDialog.java
@@ -40,7 +40,7 @@ public class SchematicInfoDialog extends BaseDialog {
         boolean portrait = Core.graphics.isPortrait();
 
         if (portrait) {
-            cont.add(new SchematicImage(data.getId(), false)).scaling(Scaling.fit)
+            cont.add(new SchematicImage(data.getItemId(), false)).scaling(Scaling.fit)
                     .maxHeight(Core.graphics.getHeight() * 0.45f)
                     .growX()
                     .pad(10f)
@@ -54,7 +54,7 @@ public class SchematicInfoDialog extends BaseDialog {
 
                 var size = Math.max(Core.graphics.getHeight() * 0.5f, Core.graphics.getWidth() * 0.5f);
 
-                main.add(new SchematicImage(data.getId(), false)).scaling(Scaling.fit)
+                main.add(new SchematicImage(data.getItemId(), false)).scaling(Scaling.fit)
                         .height(size)
                         .width(size)
                         .pad(10f)
@@ -66,7 +66,7 @@ public class SchematicInfoDialog extends BaseDialog {
 
         buttons.clearChildren();
         buttons.defaults().size(Core.graphics.isPortrait() ? 150f : 210f, 64f);
-        buttons.button("@open", Icon.link, () -> Core.app.openURI(Config.WEB_URL + "/schematics/" + data.getId())).pad(4);
+        buttons.button("@open", Icon.link, () -> Core.app.openURI(Config.WEB_URL + "/schematics/" + data.getItemId())).pad(4);
         buttons.button("@back", Icon.left, this::hide);
 
         show();

--- a/src/mindustrytool/features/chat/global/ui/MessageList.java
+++ b/src/mindustrytool/features/chat/global/ui/MessageList.java
@@ -55,7 +55,7 @@ import java.util.regex.Pattern;
 
 public class MessageList extends Table {
     private static final Pattern MINDUSTRY_TOOL_LINK_PATTERN = Pattern
-            .compile("^https?://[^/]+/[^/]+/(schematics|maps)/([0-9a-fA-F-]+)");
+            .compile("^https?://[^/]+/(?:[^/]+/)?(schematics|maps)/([a-zA-Z0-9_-]+)");
 
     private static final float TARGET_WIDTH = 250f;
     private static final float PREVIEW_BUTTON_SIZE = 50f;
@@ -402,16 +402,16 @@ public class MessageList extends Table {
         if (matcher.find()) {
             String url = matcher.group(0);
             String contentType = matcher.group(1);
-            String id = matcher.group(2);
+            String itemId = matcher.group(2);
 
             if (contentType.equals("maps")) {
-                renderMap(c, id, url);
+                renderMap(c, itemId, url);
                 c.table().growX();
                 return;
             }
 
             if (contentType.equals("schematics")) {
-                renderSchematic(c, id, url);
+                renderSchematic(c, itemId, url);
                 c.table().growX();
                 return;
             }
@@ -439,40 +439,40 @@ public class MessageList extends Table {
         }).growX().left().padTop(10);
     }
 
-    private void renderSchematic(Table table, String id, String url) {
+    private void renderSchematic(Table table, String itemId, String url) {
         table.table(Tex.pane, preview -> {
             preview.top().left().margin(0f);
             preview.table(buttons -> {
                 buttons.center().defaults().size(PREVIEW_BUTTON_SIZE);
-                buttons.button(Icon.copy, Styles.emptyi, () -> SchematicDialog.handleCopySchematic(id)).pad(2);
-                buttons.button(Icon.download, Styles.emptyi, () -> SchematicDialog.handleDownloadSchematic(id)).pad(2);
+                buttons.button(Icon.copy, Styles.emptyi, () -> SchematicDialog.handleCopySchematic(itemId)).pad(2);
+                buttons.button(Icon.download, Styles.emptyi, () -> SchematicDialog.handleDownloadSchematic(itemId)).pad(2);
                 buttons.button(Icon.info, Styles.emptyi,
-                        () -> SchematicService.findSchematicById(id)
+                        () -> SchematicService.findSchematicById(itemId)
                                 .thenAccept(schem -> Core.app.post(() -> schematicInfoDialog.show(schem))))
                         .tooltip("@info.title");
                 buttons.button(Icon.link, Styles.emptyi, () -> Core.app.openURI(url)).pad(2);
             }).growX().height(PREVIEW_BUTTON_SIZE);
             preview.row();
-            preview.stack(new Table(t -> t.add(new mindustrytool.features.browser.schematic.SchematicImage(id, true))))
+            preview.stack(new Table(t -> t.add(new mindustrytool.features.browser.schematic.SchematicImage(itemId, true))))
                     .top()
                     .left();
         }).style(Styles.flati).width(TARGET_WIDTH).height(CARD_HEIGHT).top().left();
     }
 
-    private void renderMap(Table table, String id, String url) {
+    private void renderMap(Table table, String itemId, String url) {
         table.table(Tex.pane, preview -> {
             preview.top().left().margin(0f);
             preview.table(buttons -> {
                 buttons.center().defaults().size(PREVIEW_BUTTON_SIZE);
-                buttons.button(Icon.download, Styles.emptyi, () -> MapDialog.handleDownloadMap(id)).pad(2);
+                buttons.button(Icon.download, Styles.emptyi, () -> MapDialog.handleDownloadMap(itemId)).pad(2);
                 buttons.button(Icon.info, Styles.emptyi,
-                        () -> MapService.findMapById(id)
+                        () -> MapService.findMapById(itemId)
                                 .thenAccept(m -> Core.app.post(() -> mapInfoDialog.show(m))))
                         .tooltip("@info.title");
                 buttons.button(Icon.link, Styles.emptyi, () -> Core.app.openURI(url)).pad(2);
             }).growX().height(PREVIEW_BUTTON_SIZE);
             preview.row();
-            preview.stack(new Table(t -> t.add(new MapImage(id, true)))).top().left();
+            preview.stack(new Table(t -> t.add(new MapImage(itemId, true)))).top().left();
         }).style(Styles.flati).width(TARGET_WIDTH).height(CARD_HEIGHT).top().left();
     }
 

--- a/src/mindustrytool/services/MapService.java
+++ b/src/mindustrytool/services/MapService.java
@@ -10,10 +10,10 @@ import mindustrytool.dto.MapDetailData;
 
 public class MapService {
 
-    public static CompletableFuture<byte[]> downloadMap(String id) {
+    public static CompletableFuture<byte[]> downloadMap(String itemId) {
         CompletableFuture<byte[]> future = new CompletableFuture<>();
 
-        Http.get(Config.API_URL + "maps/" + id + "/data")
+        Http.get(Config.API_URL + "maps/" + itemId + "/data")
                 .timeout(10000)
                 .error(future::completeExceptionally)
                 .submit(result -> {
@@ -23,10 +23,14 @@ public class MapService {
         return future;
     }
 
-    public static CompletableFuture<MapDetailData> findMapById(String id) {
+    public static CompletableFuture<MapDetailData> findMapById(String itemId) {
+        return findMapByItemId(itemId);
+    }
+
+    public static CompletableFuture<MapDetailData> findMapByItemId(String itemId) {
         CompletableFuture<MapDetailData> future = new CompletableFuture<>();
 
-        Http.get(Config.API_URL + "maps/" + id)
+        Http.get(Config.API_URL + "maps/" + itemId)
                 .error(future::completeExceptionally)
                 .timeout(10000)
                 .submit(response -> {

--- a/src/mindustrytool/services/SchematicService.java
+++ b/src/mindustrytool/services/SchematicService.java
@@ -9,10 +9,10 @@ import mindustrytool.dto.SchematicDetailData;
 
 public class SchematicService {
 
-    public static CompletableFuture<byte[]> downloadSchematic(String id) {
+    public static CompletableFuture<byte[]> downloadSchematic(String itemId) {
         CompletableFuture<byte[]> future = new CompletableFuture<>();
 
-        Http.get(Config.API_URL + "schematics/" + id + "/data")
+        Http.get(Config.API_URL + "schematics/" + itemId + "/data")
                 .error(future::completeExceptionally)
                 .submit(result -> {
                     future.complete(result.getResult());
@@ -21,10 +21,14 @@ public class SchematicService {
         return future;
     }
 
-    public static CompletableFuture<SchematicDetailData> findSchematicById(String id) {
+    public static CompletableFuture<SchematicDetailData> findSchematicById(String itemId) {
+        return findSchematicByItemId(itemId);
+    }
+
+    public static CompletableFuture<SchematicDetailData> findSchematicByItemId(String itemId) {
         CompletableFuture<SchematicDetailData> future = new CompletableFuture<>();
 
-        Http.get(Config.API_URL + "schematics/" + id)
+        Http.get(Config.API_URL + "schematics/" + itemId)
                 .error(future::completeExceptionally)
                 .submit(response -> {
                     try {


### PR DESCRIPTION
Also bump the mod version to v4.59.1-v8. Update the chat link matching regex to support valid alphanumeric, underscore and hyphen ID formats and optional path prefixes. Add overloaded delegate methods for map and schematic lookup, with existing findById methods delegating to the new itemId variants. Update all service calls, UI components and image handlers to use itemId consistently across all map and schematic workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map and schematic links so they work with a broader range of item identifiers.
  * Fixed map and schematic previews, information views, copying, downloads, and opening links when using non-hexadecimal identifiers.
  * Improved handling of direct map and schematic links that omit optional path segments.

* **Maintenance**
  * Updated the mod version to `v4.59.1-v8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->